### PR TITLE
Fix for no base env

### DIFF
--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -82,14 +82,13 @@ M.conda = function(opts)
 						print(env_name)
 						print('env_path')
 						print(env_path)
-						if not env_path then
-						    return conda_env_path .. '/' .. env_name .. '/bin'
-                        else
+						if env_path then
 							if string.strsub(env_path, 1, -4) == '/bin' then
 								return env_path
 							else
 								return env_path .. "/bin"
-							end
+                        else
+							return conda_env_path .. '/' .. env_name .. '/bin'
 						end
 					end
 				end

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -74,7 +74,7 @@ M.conda = function(opts)
 		attach_mappings = function(prompt_bufnr, map)
 			actions.select_default:replace(function()
 				env_to_bin = function(env)
-					if env == "base" then
+					if env == "base" or env == nil then
 						return conda_path .. "/bin"
 					else
 						return conda_env_path .. "/" .. env .. "/bin"

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -74,21 +74,32 @@ M.conda = function(opts)
 		-- TODO: There seems to be a bug if you immediately select the suggestion without moving first, that this one is not written into 
 		attach_mappings = function(prompt_bufnr, map)
 			actions.select_default:replace(function()
-				env_to_bin = function(env)
-					if env == "base" or env == nil then
+				env_to_bin = function(env_name, env_path)
+					if (env_name == "base" or env_name == nil) and (env_path == conda_path or env_path == nil or string.strsub(env_path, 1, -4) == conda_path) then
 						return conda_path .. "/bin"
 					else
-						return conda_env_path .. "/" .. env .. "/bin"
+						if env_path:strsub(1, -4) == '/bin' then
+							return env_path
+						else
+						    return env_path .. "/bin"
+						end
 					end
 				end
 				actions.close(prompt_bufnr)
 				local selection = action_state.get_selected_entry()
-				print(vim.inspect(selection))
-				local current_env = vim.env.CONDA_DEFAULT_ENV
-				local next_env = selection["display"]
-				vim.env.CONDA_DEFAULT_ENV = next_env
-				current_anaconda = env_to_bin(current_env)
-				next_anaconda = env_to_bin(next_env)
+
+				-- print(vim.inspect(selection)) -- for debugging only
+				
+				local current_env_name = vim.env.CONDA_DEFAULT_ENV_NAME
+				local current_env_path = vim.env.CONDA_DEFAULT_ENV_PATH
+
+				local next_env_name = selection["display"]
+				local next_env_path = selection['value']
+				vim.env.CONDA_DEFAULT_ENV_NAME = next_env_name
+				vim.env.CONDA_DEFAULT_ENV_PATH = next_env_path
+				current_anaconda = env_to_bin(current_env_name, current_env_path)
+				next_anaconda = env_to_bin(next_env_name, next_env_path)
+
 				-- remove it and append it separately. Otherwise might have issues when no env in path in the beginning
 				vim.env.PATH = string.gsub(vim.env.PATH, current_anaconda .. '', '')
 				vim.env.PATH = current_anaconda .. ':' .. vim.env.PATH

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -90,8 +90,6 @@ M.conda = function(opts)
 				end
 				actions.close(prompt_bufnr)
 				local selection = action_state.get_selected_entry()
-
-				-- print(vim.inspect(selection)) -- for debugging only
 				
 				local current_env_name = vim.env.CONDA_DEFAULT_ENV
 				local current_env_path = vim.env.CONDA_PREFIX

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -83,7 +83,7 @@ M.conda = function(opts)
 						print('env_path')
 						print(env_path)
 						if env_path then
-							if string.strsub(env_path, 1, -4) == '/bin' then
+							if string.sub(env_path, 1, -4) == '/bin' then
 								return env_path
 							else
 								return env_path .. "/bin"

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -99,16 +99,17 @@ M.conda = function(opts)
 				local next_env_name = selection["display"]
 				local next_env_path = selection['value']
 				vim.env.CONDA_DEFAULT_ENV = next_env_name
+				
+				current_conda = env_to_bin(current_env_name, current_env_path)
+				next_conda = env_to_bin(next_env_name, next_env_path)
 				-- remove '/bin' for prefix
-				vim.env.CONDA_PREFIX = next_env_path:sub(1, -5)
-				vim.env.CONDA_PYTHON_EXE = next_env_path .. '/python'
+				vim.env.CONDA_PREFIX = next_conda:sub(1, -5)
+				vim.env.CONDA_PYTHON_EXE = next_conda .. '/python'
 				vim.env.CONDA_PROMPT_MODIFIER = '(' .. next_env_name .. ')'
-				current_anaconda = env_to_bin(current_env_name, current_env_path)
-				next_anaconda = env_to_bin(next_env_name, next_env_path)
 
 				-- remove it and append it separately. Otherwise might have issues when no env in path in the beginning
-				vim.env.PATH = string.gsub(vim.env.PATH, current_anaconda .. '', '')
-				vim.env.PATH = next_anaconda .. ':' .. vim.env.PATH
+				vim.env.PATH = string.gsub(vim.env.PATH, current_conda .. '', '')
+				vim.env.PATH = next_conda .. ':' .. vim.env.PATH
 			end)
 			return true
 		end,

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -93,13 +93,15 @@ M.conda = function(opts)
 
 				-- print(vim.inspect(selection)) -- for debugging only
 				
-				local current_env_name = vim.env.CONDA_DEFAULT_ENV_NAME
-				local current_env_path = vim.env.CONDA_DEFAULT_ENV_PATH
+				local current_env_name = vim.env.CONDA_DEFAULT_ENV
+				local current_env_path = vim.env.CONDA_PREFIX
 
 				local next_env_name = selection["display"]
 				local next_env_path = selection['value']
-				vim.env.CONDA_DEFAULT_ENV_NAME = next_env_name
-				vim.env.CONDA_DEFAULT_ENV_PATH = next_env_path
+				vim.env.CONDA_DEFAULT_ENV = next_env_name
+				vim.env.CONDA_PREFIX = next_env_path.sub(-4)
+				vim.env.CONDA_PYTHON_EXE = next_env_path .. '/python'
+				vim.env.CONDA_PROMPT_MODIFIER = '(' .. next_env_name .. ')'
 				current_anaconda = env_to_bin(current_env_name, current_env_path)
 				next_anaconda = env_to_bin(next_env_name, next_env_path)
 

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -89,7 +89,7 @@ M.conda = function(opts)
 				next_anaconda = env_to_bin(next_env)
 				-- remove it and append it separately. Otherwise might have issues when no env in path in the beginning
 				vim.env.PATH = string.gsub(vim.env.PATH, current_anaconda, '')
-				vim.env.PATH = current_anaconda .. ':' .. vim.env.PATH:
+				vim.env.PATH = current_anaconda .. ':' .. vim.env.PATH
 			end)
 			return true
 		end,

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -81,7 +81,7 @@ M.conda = function(opts)
 						if env_path == nil then
 						    return conda_env_path .. '/' .. env_name .. '/bin'
                         else
-							if env_path:strsub(1, -4) == '/bin' then
+							if string.strsub(env_path, 1, -4) == '/bin' then
 								return env_path
 							else
 								return env_path .. "/bin"

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -78,6 +78,8 @@ M.conda = function(opts)
 					if env_name == "base" or env_name == nil then
 						return conda_path .. "/bin"
 					else
+						print(env_name)
+						print(env_path)
 						if env_path == nil then
 						    return conda_env_path .. '/' .. env_name .. '/bin'
                         else

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -99,7 +99,8 @@ M.conda = function(opts)
 				local next_env_name = selection["display"]
 				local next_env_path = selection['value']
 				vim.env.CONDA_DEFAULT_ENV = next_env_name
-				vim.env.CONDA_PREFIX = next_env_path.sub(-4)
+				-- remove '/bin' for prefix
+				vim.env.CONDA_PREFIX = next_env_path:sub(1, -5)
 				vim.env.CONDA_PYTHON_EXE = next_env_path .. '/python'
 				vim.env.CONDA_PROMPT_MODIFIER = '(' .. next_env_name .. ')'
 				current_anaconda = env_to_bin(current_env_name, current_env_path)

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -75,14 +75,14 @@ M.conda = function(opts)
 		attach_mappings = function(prompt_bufnr, map)
 			actions.select_default:replace(function()
 				env_to_bin = function(env_name, env_path)
-					if env_name == "base" or env_name == nil then
+					if env_name == "base" or not env_name then
 						return conda_path .. "/bin"
 					else
 						print('env_name')
 						print(env_name)
 						print('env_path')
 						print(env_path)
-						if env_path == nil then
+						if not env_path then
 						    return conda_env_path .. '/' .. env_name .. '/bin'
                         else
 							if string.strsub(env_path, 1, -4) == '/bin' then

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -87,7 +87,9 @@ M.conda = function(opts)
 				vim.env.CONDA_DEFAULT_ENV = next_env
 				current_anaconda = env_to_bin(current_env)
 				next_anaconda = env_to_bin(next_env)
-				vim.env.PATH = string.gsub(vim.env.PATH, current_anaconda, next_anaconda)
+				-- remove it and append it separately. Otherwise might have issues when no env in path in the beginning
+				vim.env.PATH = string.gsub(vim.env.PATH, current_anaconda, '')
+				vim.env.PATH = current_anaconda .. ':' .. vim.env.PATH:
 			end)
 			return true
 		end,

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -71,6 +71,7 @@ M.conda = function(opts)
 		finder = conda_finder(),
 		sorter = conf.generic_sorter(opts),
 
+		-- TODO: There seems to be a bug if you immediately select the suggestion without moving first, that this one is not written into 
 		attach_mappings = function(prompt_bufnr, map)
 			actions.select_default:replace(function()
 				env_to_bin = function(env)
@@ -82,13 +83,14 @@ M.conda = function(opts)
 				end
 				actions.close(prompt_bufnr)
 				local selection = action_state.get_selected_entry()
+				print(vim.inspect(selection))
 				local current_env = vim.env.CONDA_DEFAULT_ENV
 				local next_env = selection["display"]
 				vim.env.CONDA_DEFAULT_ENV = next_env
 				current_anaconda = env_to_bin(current_env)
 				next_anaconda = env_to_bin(next_env)
 				-- remove it and append it separately. Otherwise might have issues when no env in path in the beginning
-				vim.env.PATH = string.gsub(vim.env.PATH, current_anaconda, '')
+				vim.env.PATH = string.gsub(vim.env.PATH, current_anaconda .. '', '')
 				vim.env.PATH = current_anaconda .. ':' .. vim.env.PATH
 			end)
 			return true

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -75,7 +75,7 @@ M.conda = function(opts)
 		attach_mappings = function(prompt_bufnr, map)
 			actions.select_default:replace(function()
 				env_to_bin = function(env_name, env_path)
-					if (env_name == "base" or env_name == nil) and (env_path == conda_path or env_path == nil or (value ~=nil and string.strsub(env_path, 1, -4)) == conda_path) then
+					if env_name == "base" or env_name == nil then
 						return conda_path .. "/bin"
 					else
 						if env_path:strsub(1, -4) == '/bin' then

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -78,7 +78,9 @@ M.conda = function(opts)
 					if env_name == "base" or env_name == nil then
 						return conda_path .. "/bin"
 					else
+						print('env_name')
 						print(env_name)
+						print('env_path')
 						print(env_path)
 						if env_path == nil then
 						    return conda_env_path .. '/' .. env_name .. '/bin'

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -71,17 +71,12 @@ M.conda = function(opts)
 		finder = conda_finder(),
 		sorter = conf.generic_sorter(opts),
 
-		-- TODO: There seems to be a bug if you immediately select the suggestion without moving first, that this one is not written into 
 		attach_mappings = function(prompt_bufnr, map)
 			actions.select_default:replace(function()
 				env_to_bin = function(env_name, env_path)
 					if env_name == "base" or not env_name then
 						return conda_path .. "/bin"
 					else
-						print('env_name')
-						print(env_name)
-						print('env_path')
-						print(env_path)
 						if env_path then
 							if string.sub(env_path, 1, -4) == '/bin' then
 								return env_path
@@ -110,7 +105,7 @@ M.conda = function(opts)
 
 				-- remove it and append it separately. Otherwise might have issues when no env in path in the beginning
 				vim.env.PATH = string.gsub(vim.env.PATH, current_anaconda .. '', '')
-				vim.env.PATH = current_anaconda .. ':' .. vim.env.PATH
+				vim.env.PATH = next_anaconda .. ':' .. vim.env.PATH
 			end)
 			return true
 		end,

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -75,7 +75,7 @@ M.conda = function(opts)
 		attach_mappings = function(prompt_bufnr, map)
 			actions.select_default:replace(function()
 				env_to_bin = function(env_name, env_path)
-					if (env_name == "base" or env_name == nil) and (env_path == conda_path or env_path == nil or string.strsub(env_path, 1, -4) == conda_path) then
+					if (env_name == "base" or env_name == nil) and (env_path == conda_path or env_path == nil or (value ~=nil and string.strsub(env_path, 1, -4)) == conda_path) then
 						return conda_path .. "/bin"
 					else
 						if env_path:strsub(1, -4) == '/bin' then

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -78,10 +78,14 @@ M.conda = function(opts)
 					if env_name == "base" or env_name == nil then
 						return conda_path .. "/bin"
 					else
-						if env_path:strsub(1, -4) == '/bin' then
-							return env_path
-						else
-						    return env_path .. "/bin"
+						if env_path == nil then
+						    return conda_env_path .. '/' .. env_name .. '/bin'
+                        else
+							if env_path:strsub(1, -4) == '/bin' then
+								return env_path
+							else
+								return env_path .. "/bin"
+							end
 						end
 					end
 				end

--- a/lua/telescope/_extensions/conda/main.lua
+++ b/lua/telescope/_extensions/conda/main.lua
@@ -87,6 +87,7 @@ M.conda = function(opts)
 								return env_path
 							else
 								return env_path .. "/bin"
+							end
                         else
 							return conda_env_path .. '/' .. env_name .. '/bin'
 						end


### PR DESCRIPTION
As discussed in #2 this fixes the following: 

- Handle cases if `vim.env.CONDA_DEFAULT_ENV` is not set (`nil`) -> will default to base now.
- Handle cases, where Path does not yet contain the prefix (Happens if no env is pre-activated). Currently the substitution wouldn't work then (at least it didn't for me).
- Also rely on `vim.env.CONDA_PREFIX` if given (and the path corresponding to the selected env)
- Set other conda variables like `CONDA_PREFIX`, `CONDA_PYTHON_EXE` and `CONDA_PROMPT_MODIFIER`


Note that this probably should be merged with squashing since it's a quite verbose commit history :D
